### PR TITLE
the acme solver should not be named icp

### DIFF
--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -32,7 +32,7 @@ image:
   pullPolicy: IfNotPresent
 
 solver:
-  name: icp-cert-manager-acmesolver
+  name: cert-manager-acmesolver
   repository: quay.io/open-cluster-management
   tag: 0.10.1
 


### PR DESCRIPTION
This is a fix for the name of the acme solver image.  The icp prefix was already removed from the image name. https://github.com/open-cluster-management/backlog/issues/1144