### PR TITLE
do not use release name for the webhook secrets

### DIFF
--- a/stable/cert-manager/templates/secret.yaml
+++ b/stable/cert-manager/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "cert-manager.fullname" . }}-webhook-ca
+  name: cert-manager-webhook-ca
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "cert-manager.name" . }}
@@ -16,7 +16,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "cert-manager.fullname" . }}-webhook-tls
+  name: cert-manager-webhook-tls
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "cert-manager.name" . }}


### PR DESCRIPTION
The release name in ACM has some special naming which did not show up when I manually test.  I am not using the release name now.
https://github.com/open-cluster-management/backlog/issues/787