### PR TITLE
increase the memory limit due to seeing some OOM

### DIFF
--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -64,7 +64,7 @@ resources:
     memory: "150Mi"
     cpu: "100m"
   limits:
-    memory: "300Mi"
+    memory: "768Mi"
     cpu: "300m"
 
 # Pod Security Context


### PR DESCRIPTION
Issue https://github.com/open-cluster-management/backlog/issues/4915
Seen on 2.1 and on 2.0 on different OCP builds.
Not clear why additional memory is used.  May be specific to OCP configuration