### PR TITLE
uncomment the flag to enable owner refs in secrets

### DIFF
--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -53,7 +53,7 @@ extraArgs:
   # supporting resources required for each ClusterIssuer (default is kube-system)
   # - --cluster-resource-namespace=kube-system
   # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
-  # - --enable-certificate-owner-ref=true
+  - --enable-certificate-owner-ref=true
 
 extraEnv:
  - name: OWNED_NAMESPACE


### PR DESCRIPTION
This is needed by observability squad which will be creating certificates in multiple namespaces other than the `open-cluster-management` namespace.
https://github.com/open-cluster-management/backlog/issues/5129