### PR TITLE
use a different namespace for cluster issuer resources

### DIFF
--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         {{- if .Values.clusterResourceNamespace }}
           - --cluster-resource-namespace={{ .Values.clusterResourceNamespace }}
         {{- else }}
-          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --cluster-resource-namespace=$(POD_NAMESPACE)-issuer
         {{- end }}
         {{- if .Values.global.leaderElection.namespace }}
           - --leader-election-namespace={{ .Values.global.leaderElection.namespace }}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -38,7 +38,7 @@ strategy: {}
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
 # resources. By default, the same namespace as cert-manager is deployed within is
 # used. This namespace will not be automatically created by the Helm chart.
-clusterResourceNamespace: "ibm-common-services"
+# clusterResourceNamespace: "ibm-common-services"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Uses `open-cluster-management-issuer` as the cluster resources namespace.  If the ACM namespace is set to `fred` then the value would be `fred-issuer`.
https://github.com/open-cluster-management/backlog/issues/5532